### PR TITLE
update helper.js due to many-to-many associations fails on update

### DIFF
--- a/lib/waterline/utils/helpers.js
+++ b/lib/waterline/utils/helpers.js
@@ -66,7 +66,7 @@ exports.object = {};
 
 var hop = Object.prototype.hasOwnProperty;
 exports.object.hasOwnProperty = function(obj, prop) {
-  if (obj === null) return false;
+  if (obj === null || obj === undefined) return false;
   return hop.call(obj, prop);
 };
 


### PR DESCRIPTION
 return hop.call(obj, prop);
             ^
TypeError: Cannot convert null to object
    at hasOwnProperty (native)